### PR TITLE
Update 10_django.md

### DIFF
--- a/website/content/08_web_frameworks/10_django.md
+++ b/website/content/08_web_frameworks/10_django.md
@@ -32,7 +32,7 @@ We're going to install these dependencies in our newly created virtual environme
 Note, if you're already in a virtual environment, type `deactivate` or open a new terminal window.
 
 ```bash
-$ python -m venv env
+$ python3 -m venv env
 $ source env/bin/activate
 (env) $ python -m pip install -r requirements.txt
 ```


### PR DESCRIPTION
The "python - m venv env" command to create the virtual environment doesn't work. We should use "python3" instead.